### PR TITLE
Fix bugs found in Windows testing

### DIFF
--- a/Write-Log/Tests/Write-Log.Tests.ps1
+++ b/Write-Log/Tests/Write-Log.Tests.ps1
@@ -1,3 +1,4 @@
+
 Describe 'Write-Log' {
     BeforeAll {
         # Ensure the module is imported
@@ -6,7 +7,8 @@ Describe 'Write-Log' {
 
     BeforeEach {
         # Mock dependencies and setup test environment
-        $TestLogDirectory = Join-Path -Path $env:TMPDIR -ChildPath 'TestLogs'
+        $tempDir = ($IsMacOS ? "${env:TMPDIR}" : $IsLinux ? '/var/tmp' : "${env:Temp}")
+        $TestLogDirectory = Join-Path -Path $tempDir -ChildPath 'TestLogs'
         $TestLogFileName = 'TestLog.log'
         $TestLogFilePath = Join-Path -Path $TestLogDirectory -ChildPath $TestLogFileName
 
@@ -23,7 +25,6 @@ Describe 'Write-Log' {
             Remove-Item -Path $TestLogDirectory -Recurse -Force
         }
     }
-
     Context 'Parameter validation and edge cases' {
         It 'Should log multiple messages from array input' {
             $Messages = @('First', 'Second', 'Third')
@@ -157,7 +158,7 @@ Describe 'Write-Log' {
         }
 
         It 'Should handle absolute LogFileDirectory path' {
-            $AbsoluteDir = Join-Path -Path $env:TMPDIR -ChildPath 'AbsoluteTestLogs'
+            $AbsoluteDir = Join-Path -Path $tempDir -ChildPath 'AbsoluteTestLogs'
             if (-not (Test-Path $AbsoluteDir)) { New-Item -Path $AbsoluteDir -ItemType Directory | Out-Null }
             Write-Log -Message 'Absolute path test' -LogFileDirectory $AbsoluteDir -LogFileName $TestLogFileName
             Test-Path -Path (Join-Path $AbsoluteDir $TestLogFileName) | Should -BeTrue

--- a/Write-Log/Write-Log.ps1
+++ b/Write-Log/Write-Log.ps1
@@ -1,3 +1,4 @@
+#requires -Version 7
 #region Function Write-Log
 Function Write-Log {
     <#
@@ -95,6 +96,9 @@ Function Write-Log {
         Taken from PSAppDeployToolkit v3.10.2. Modified to remove PSADT dependencies and to work cross-platform.
     #>
     [CmdletBinding()]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'Write-Log does not exist in any version of PowerShell.')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleSyntax', '', Justification = 'Requires statement ensures only running in PowerShell 7')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'If used in an interactive session, we want data sent back to user.')]
     Param (
         [Parameter(
             Mandatory,
@@ -115,7 +119,7 @@ Function Write-Log {
         [String]$LogType = (Get-Command -Name 'cmtrace.exe' -ErrorAction SilentlyContinue) ? 'CMTrace' : 'Legacy',
         [Parameter()]
         [ValidateNotNullOrWhiteSpace()]
-        [String]$LogFileDirectory,
+        [String]$LogFileDirectory = $IsMacOS ? "${env:TMPDIR}" : $IsLinux ? '/var/tmp' : "${env:Temp}", # If not Mac or Linux, default to Windows
         [Parameter()]
         [ValidateNotNullOrWhiteSpace()]
         [String]$LogFileName = [IO.Path]::GetFileNameWithoutExtension([IO.Path]::GetRandomFileName()),
@@ -142,17 +146,6 @@ Function Write-Log {
     Begin {
         ## Get the name of this function, used only if an error occurs writing to the log file
         [String]${CmdletName} = $PSCmdlet.MyInvocation.MyCommand.Name
-
-        # Set LogFileDir to Temporary directory if not specified
-        $LogFileDirectory ??= {
-            if($IsWindows){
-                $env:TEMP
-            } elseif ($IsMacOS){
-                $env:TMPDIR
-            } elseif ($IsLinux){
-                '/var/tmp'
-            }
-        }
 
         # Ensure we have an extension for the log file name, default to .log
         $LogFileName = (Split-Path $LogFileName -Extension) ? $LogFileName : "${LogFileName}.log"
@@ -385,6 +378,7 @@ Function Write-Log {
         If ($PassThru) {
             Write-Output -InputObject ($Message)
         }
+        Write-Verbose "${LogFileDirectory}\${LogFileName}"
     }
 }
 #endregion


### PR DESCRIPTION
- TempDir dynamically set in Tests.ps1
- Add Requires -Version 7 to Write-Log.ps1
- Add PSScriptAnalyzer Suppression
- Update LogFileDirectory Parameter logic